### PR TITLE
pull faviconFile from project which pull from .env

### DIFF
--- a/gulpfileDir/config/paths.js
+++ b/gulpfileDir/config/paths.js
@@ -1,5 +1,7 @@
-const name = 'AccuTheme';
-const faviconFile = 'favicon.png';
+// import { env } from 'process'; //How to access process.env in ES6
+import { name, faviconFile } from './project.js';
+// const name = 'AccuTheme';
+// const { faviconFile } = env;
 const SRC_NAME = 'src';
 const DIST_NAME = 'dist';
 


### PR DESCRIPTION
The favicon file name was set to a hardcoded value after the update to ESM. Fixed to pulled the faviconFile name from project.js, which pulls the faviconFile name from .env as expected.