### PR TITLE
fixes empty svgs issue #39

### DIFF
--- a/gulpfileDir/config/plugins.js
+++ b/gulpfileDir/config/plugins.js
@@ -38,19 +38,14 @@ const imagemin = {
     gifsicle({ interlaced: true }),
     svgo({
       plugins: [
-        {
-          name: 'preset-default',
-          params: {
-            cleanupAttrs: true,
-            cleanupIDs: false,
-            removeComments: true,
-            removeDesc: false,
-            removeStyleElement: true,
-            removeTitle: false,
-            removeUnknownsAndDefaults: false, // keeps `role="image"`
-            removeViewBox: false,
-          },
-        },
+        { name: 'cleanupAttrs', active: true },
+        { name: 'cleanupIDs', active: false },
+        { name: 'removeComments', active: true },
+        { name: 'removeDesc', active: false },
+        { name: 'removeStyleElement', active: true },
+        { name: 'removeTitle', active: false },
+        { name: 'removeUnknownsAndDefaults', active: false }, // keeps `role="image"`
+        { name: 'removeViewBox', active: true },
       ],
     }),
     mozjpeg({


### PR DESCRIPTION
AccuTheme.AccuIcon() was not working because optimized asset was empty. See issue #39. updates plugin options to modern (object) formatting.