### PR TITLE
Update sftp.json.example

### DIFF
--- a/.vscode/sftp.json.example
+++ b/.vscode/sftp.json.example
@@ -29,6 +29,7 @@
     "**/src/",
     "**/README.md",
     "**/*.LICENSE.txt",
+     "**/web.config",
     ".*",
     "package.json",
     "package-lock.json",


### PR DESCRIPTION
In most cases it is a mistake to auto-upload web.config on save. So we will exclude it from now on and be required to manually upload. This is because it is usually out of date if any modules have been upgraded (e.g. 2sxc  modifies web.config) and needs to be downloaded first before making changes and uploading. Accidentally uploading an old version will almost always take a site down immediately.